### PR TITLE
Only consider bases that pass a certain quality threshold when calcul…

### DIFF
--- a/src/lofreq/plp.c
+++ b/src/lofreq/plp.c
@@ -148,6 +148,7 @@ plp_col_init(plp_col_t *p) {
     p->ref_base = '\0';
     p->cons_base[0] = 'N'; p->cons_base[1] = '\0';
     p->coverage_plp = 0;
+    p->min_bq_filtered_bases = 0;
     p->num_bases = 0;
     p->num_ign_indels = 0;
     p->num_non_indels = 0;
@@ -931,6 +932,7 @@ void compile_plp_col(plp_col_t *plp_col,
                 * and might skew AFs etc
                 */
                if (bq < conf->min_plp_bq) {
+                    plp_col->min_bq_filtered_bases++;
                     base_skip = 1;
                     /* NOTE: all values used after check_indel need to be initialized before this goto */
                     goto check_indel; /* goto was easiest */

--- a/src/lofreq/plp.h
+++ b/src/lofreq/plp.h
@@ -76,6 +76,7 @@ typedef struct {
      char ref_base; /* uppercase reference base (given by fasta) */
      char cons_base[MAX_INDELSIZE]; /* uppercase consensus base according to base-counts, after read-level filtering. */
      int coverage_plp; /* original samtools value. upper count limit for all kept values */
+     int min_bq_filtered_bases; /* number of bases filtered out from min base qual filter */
      int num_bases; /* number of bases after base filtering */
      /* num_ins and num_dels gives 'num_indels' */
      int num_ign_indels; /* a hack: indels often get filtered because of low quality of missing qualities in bam file. we need to know nevertheless they are present. this is the count of all "ignored" indels */


### PR DESCRIPTION
…ating depth (DP) and allele frequency (AF).  Use a new command-line flag, --min-blind-bq, for this to maintain backwards compatibility.
