### PR TITLE
Convert lofreq to use the HTSlib API instead of the legacy samtools API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ compiler:
 # Change this to your needs
 # Change this to your needs
 before_script:
-  - wget 'http://downloads.sourceforge.net/project/samtools/samtools/1.1/samtools-1.1.tar.bz2' -O /tmp/samtools-1.1.tar.bz2
-  - tar -xjf /tmp/samtools-1.1.tar.bz2
-  - cd samtools-1.1/
-  - make
+  - wget 'https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2' -O /tmp/htslib-1.9.tar.bz2
+  - tar -xjf /tmp/htslib-1.9.tar.bz2
+  - cd htslib-1.9/
+  - make libhts.a htslib_static.mk
   - cd ..
-script: libtoolize; ./bootstrap && ./configure SAMTOOLS=${PWD}/samtools-1.1/ HTSLIB=${PWD}/samtools-1.1/htslib-1.1/ && make
+script: libtoolize; ./bootstrap && ./configure --with-htslib=${PWD}/htslib-1.9 && make

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ You will need:
 - a C compiler (e.g. gcc or clang)
 - a Python 2.7 or Python 3 interpreter
 - zlib developer files
-- a compiled version of [samtools 1.1]((http://sourceforge.net/projects/samtools/files/samtools/1.1/samtools-1.1.tar.bz2/download))
-- a compiled version of htslib 1.1; use the one that comes bundled with samtools!)
+- a compiled version of [HTSlib 1.4 or later](https://github.com/samtools/htslib)
 
 ### Compilation
 
@@ -36,9 +35,8 @@ You will need:
     `bootstrap` again
   - Subsequent pulls won't require rerunning `./bootstrap`. This is
     only necesary when changing `configure.ac` or any of the `Makefile.am`
-- Run `./configure` with the **absolute** path to samtools and htslib
-  (e.g. `./configure SAMTOOLS=/path-to-samtools HTSLIB=/path-to-htslib
-  [--prefix=inst-path]`)
+- Run `./configure` with the **absolute** path to HTSlib
+  (e.g. `./configure --with-htslib=/path-to-htslib [--prefix=inst-path]`)
 - Run `make`
   - At this point you can already start using lofreq: `./bin/lofreq`
 - Run `make install` to properly install the package

--- a/configure.ac
+++ b/configure.ac
@@ -186,25 +186,19 @@ else
     # Could set -O3 but that should be a user choice (env var CFLAGS)
 fi
 
-# currently samtools/libbam and htslib are not properly installed by default
-# so we use an envvar to point us to the directory
-#AC_LIB_LINKFLAGS([hts])
-#AC_LIB_LINKFLAGS([bam])
-AC_ARG_VAR(SAMTOOLS, [*Absolute* path to precompiled samtools source directory])
-if test x"$SAMTOOLS" = x""; then
-   AC_MSG_ERROR([Samtools directory not defined. Please use SAMTOOLS=/fullpath/to/samtoolsdir/])
+if test x"$HTSLIB" != x""; then
+   AC_MSG_ERROR([Use --with-htslib=/fullpath/to/htslibdir instead of HTSLIB variable])
 fi
-AC_ARG_VAR(HTSLIB, [*Absolute* path to precompiled htslib source directory])
-if test x"$HTSLIB" = x""; then
-   AC_MSG_ERROR([Htslib directory not defined. Please use HTSLIB=/fullpath/to/htslibdir/])
+m4_include([m4/ax_with_htslib.m4])
+AX_WITH_HTSLIB
+if test "$ax_cv_htslib" != yes; then
+   AC_MSG_ERROR([HTSlib not found])
 fi
-AC_CHECK_FILE(${SAMTOOLS}/bam.h, [], [AC_MSG_ERROR([bam.h not found])])
-AC_CHECK_FILE(${HTSLIB}/htslib/hts.h, [], [AC_MSG_ERROR([hts.h not found])])
+AM_CONDITIONAL([HTSLIB_IS_SRC], [test "$ax_cv_htslib_which" = source])
 
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_LDFLAGS])
 
-AC_DEFINE([_USE_KNETFILE], [1], [KNETFILE for samtools])
 # AC_DEFINE([SOURCEQUAL_IGNORES_INDELS], [1], [ignore indels in SQ computation as long as we can't predict them])
 
 

--- a/devel-doc/docker.README
+++ b/devel-doc/docker.README
@@ -21,20 +21,20 @@ ln -s /usr/bin/python2.7 /usr/bin/python
 cd /usr/local/src
 wget -nd 'http://downloads.sourceforge.net/project/lofreq/lofreq_star-2.1.1.tar.gz'
 #
-wget 'http://downloads.sourceforge.net/project/samtools/samtools/1.1/samtools-1.1.tar.bz2'
-tar -xjf samtools-1.1.tar.bz2
-cd samtools-1.1
+wget 'https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2'
+tar -xjf htslib-1.9.tar.bz2
+cd htslib-1.9
 make
 make install
 
 cd ..
 tar xvzf lofreq_star-2.1.1.tar.gz
 cd lofreq_star-2.1.1
-./configure SAMTOOLS=/usr/local/src/samtools-1.1/ HTSLIB=/usr/local/src/samtools-1.1/htslib-1.1/
+./configure --with-htslib=/usr/local
 make
 make install
 
 # ---
 
-docker commit -m="Added samtools/htslib 1.1 and lofreq 2.1.1" -a="Andreas Wilm" 78c85ef2e74a andreaswilm/lofreq:v2.1.1
+docker commit -m="Added htslib 1.9 and lofreq 2.1.1" -a="Andreas Wilm" 78c85ef2e74a andreaswilm/lofreq:v2.1.1
 docker push andreaswilm/lofreq

--- a/m4/ax_with_htslib.m4
+++ b/m4/ax_with_htslib.m4
@@ -1,0 +1,154 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_with_htslib.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_WITH_HTSLIB
+#
+# DESCRIPTION
+#
+#   This macro checks whether HTSlib <http://www.htslib.org/> is installed
+#   or nearby, and adds a --with-htslib=DIR option to the configure script
+#   for specifying the location.  It locates either an installation prefix
+#   (with 'include' and 'lib' subdirectories) or an HTSlib source tree, as
+#   HTSlib is fast-moving and users may wish to use an in-development tree.
+#
+#   Different checks occur depending on the --with-htslib argument given:
+#
+#   With --with-htslib=DIR, checks whether DIR is a source tree or contains
+#     a working installation.
+#   By default, searches for a source tree (with a name matching htslib*)
+#     within or alongside $srcdir.  Produces AC_MSG_ERROR if there are
+#     several equally-likely candidates.  If there are none, checks for
+#     a working default installation.
+#   With --with-htslib=system, checks for a working default installation.
+#
+#   If a source tree is found or specified, it is added to AC_CONFIG_SUBDIRS
+#   if either --enable-configure-htslib is set, or where htslib is included
+#   in a subdirectory (for packages that want to supply an embedded htslib).
+#   Unfortunately this may cause a "you should use literals" warning when
+#   autoconf is run.
+#
+#   The following output variables are set by this macro:
+#
+#     HTSDIR              Directory containing HTSlib source tree
+#     HTSLIB_CPPFLAGS     Preprocessor flags for compiling with HTSlib
+#     HTSLIB_LDFLAGS      Linker flags for linking with HTSlib
+#
+#   The following shell variables may be defined:
+#
+#     ax_cv_htslib        Set to "yes" if HTSlib was found
+#     ax_cv_htslib_which  Set to "source", "install", or "none"
+#
+# LICENSE
+#
+#   Copyright (C) 2015,2017 Genome Research Ltd
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_WITH_HTSLIB],
+[AC_ARG_WITH([htslib],
+  [AS_HELP_STRING([--with-htslib=DIR],
+    [use the HTSlib source tree or installation in DIR])
+dnl Not indented, to avoid extra whitespace outwith AS_HELP_STRING()
+AS_HELP_STRING([--with-htslib=system],
+    [use only a system HTSlib installation])],
+  [], [with_htslib=search])
+AC_ARG_ENABLE([configure-htslib],
+  [AS_HELP_STRING([--enable-configure-htslib],
+     [run configure for htslib as well @<:@default=only_in_subdir@:>@])],
+  [], [enable_configure_htslib=only_in_subdir])
+
+case $with_htslib in
+yes|search)
+  AC_MSG_CHECKING([location of HTSlib source tree])
+  case $srcdir in
+    .) srcp= ;;
+    *) srcp=$srcdir/ ;;
+  esac
+  found=
+  for dir in ${srcp}htslib* -- ${srcp}../htslib -- ${srcp}../htslib*
+  do
+    if test "$dir" = "--"; then
+      test -n "$found" && break
+    elif test -f "$dir/hts.c" && test -f "$dir/htslib/hts.h"; then
+      found="${found}1"
+      HTSDIR=$dir
+    fi
+  done
+  if test -z "$found"; then
+    AC_MSG_RESULT([none found])
+    ax_cv_htslib_which=system
+  elif test "$found" = 1; then
+    AC_MSG_RESULT([$HTSDIR])
+    ax_cv_htslib_which=source
+    if test "x$enable_configure_htslib" = "xonly_in_subdir" ; then
+      case $HTSDIR in
+        "${srcp}htslib"*) enable_configure_htslib=yes ;;
+        *) ;;
+      esac
+    fi
+  else
+    AC_MSG_RESULT([several directories found])
+    AC_MSG_ERROR([use --with-htslib=DIR to select which HTSlib to use])
+  fi
+  ;;
+no) ax_cv_htslib_which=none ;;
+system) ax_cv_htslib_which=system ;;
+*)
+  HTSDIR=$with_htslib
+  if test -f "$HTSDIR/hts.c" && test -f "$HTSDIR/htslib/hts.h"; then
+    ax_cv_htslib_which=source
+  else
+    ax_cv_htslib_which=install
+  fi
+  ;;
+esac
+
+case $ax_cv_htslib_which in
+source)
+  ax_cv_htslib=yes
+  HTSLIB_CPPFLAGS="-I$HTSDIR"
+  HTSLIB_LDFLAGS="-L$HTSDIR"
+  if test "x$enable_configure_htslib" = "xyes"; then
+    # We can't use a literal, because $HTSDIR is user-provided and variable
+    AC_CONFIG_SUBDIRS($HTSDIR)
+  fi
+  ;;
+system)
+  AC_CHECK_HEADER([htslib/sam.h],
+    [AC_CHECK_LIB(hts, hts_version, [ax_cv_htslib=yes], [ax_cv_htslib=no])],
+    [ax_cv_htslib=no], [;])
+  ax_cv_htslib_which=install
+  HTSDIR=
+  HTSLIB_CPPFLAGS=
+  HTSLIB_LDFLAGS=
+  ;;
+install)
+  ax_saved_CPPFLAGS=$CPPFLAGS
+  ax_saved_LDFLAGS=$LDFLAGS
+  HTSLIB_CPPFLAGS="-I$HTSDIR/include"
+  HTSLIB_LDFLAGS="-L$HTSDIR/lib"
+  CPPFLAGS="$CPPFLAGS $HTSLIB_CPPFLAGS"
+  LDFLAGS="$LDFLAGS $HTSLIB_LDFLAGS"
+  AC_CHECK_HEADER([htslib/sam.h],
+    [AC_CHECK_LIB(hts, hts_version, [ax_cv_htslib=yes], [ax_cv_htslib=no])],
+    [ax_cv_htslib=no], [;])
+  HTSDIR=
+  CPPFLAGS=$ax_saved_CPPFLAGS
+  LDFLAGS=$ax_saved_LDFLAGS
+  ;;
+none)
+  ax_cv_htslib=no
+  ;;
+esac
+
+AC_SUBST([HTSDIR])
+AC_SUBST([HTSLIB_CPPFLAGS])
+AC_SUBST([HTSLIB_LDFLAGS])])

--- a/src/lofreq/Makefile.am
+++ b/src/lofreq/Makefile.am
@@ -1,4 +1,5 @@
-AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -I../cdflib90/ -I../uthash -I@HTSLIB@ -I@SAMTOOLS@ @AM_CFLAGS@
+AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -I../cdflib90/ -I../uthash $(HTSLIB_CPPFLAGS) @AM_CFLAGS@
+AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@
 bin_PROGRAMS = lofreq
 lofreq_SOURCES = bam_md_ext.c bam_md_ext.h \
 bedidx.c bam_index.c \
@@ -26,7 +27,18 @@ vcf.c vcf.h \
 viterbi.c viterbi.h
 #lofreq_bamstats.h lofreq_bamstats.c
 
+if HTSLIB_IS_SRC
+
+include $(HTSDIR)/htslib_static.mk
+LDFLAGS_for_htslib = $(HTSLIB_static_LDFLAGS)
+LIBS_for_htslib = $(HTSDIR)/libhts.a $(HTSLIB_static_LIBS)
+
+else
+
+LDFLAGS_for_htslib = $(HTSLIB_LDFLAGS)
+LIBS_for_htslib = -lhts
+
+endif
 
 # note: order matters
-#lofreq_LDADD = @htslib_dir@/libhts.a @samtools_dir@/libbam.a
-lofreq_LDADD = @HTSLIB@/libhts.a @SAMTOOLS@/libbam.a ../cdflib90/libcdf.a
+lofreq_LDADD = $(LIBS_for_htslib) ../cdflib90/libcdf.a

--- a/src/lofreq/lofreq_call.c
+++ b/src/lofreq/lofreq_call.c
@@ -47,9 +47,9 @@
 #include <getopt.h>
 #include <stdlib.h>
 
-/* libbam includes */
+/* htslib includes */
 #include "htslib/faidx.h"
-#include "sam.h"
+#include "htslib/sam.h"
 #include "htslib/kstring.h"
 
 /* from bedidx.c */

--- a/src/lofreq/lofreq_index.c
+++ b/src/lofreq/lofreq_index.c
@@ -4,10 +4,11 @@
 
 #include <ctype.h>
 #include <assert.h>
+#include <stdlib.h>
 
-/* samtools includes */
-#include "bam.h"
-#include "sam.h"
+/* htslib includes */
+#include "htslib/faidx.h"
+#include "htslib/sam.h"
 
 /* bam_index actually part of API but bam_idxstats not */
 int bam_index(int argc, char *argv[]);
@@ -26,15 +27,13 @@ int bam_idxstats(int argc, char *argv[]);
 
 int main_faidx(int argc, char *argv[]) 
 {
-     char *fi; char *fa;
+     char *fa;
      
      fa = argv[2];
-     fi = samfaipath(fa);
-     if (! fi) {
+     if (fai_build(fa) < 0) {
           return 1;
      }
 
-     free(fi);
      return 0;
 }
 
@@ -42,7 +41,7 @@ int
 main_index(int argc, char *argv[])
 {
      char *b = argv[2];
-     return bam_index_build(b);
+     return sam_index_build(b, 0);
 }
 
 int

--- a/src/lofreq/samutils.h
+++ b/src/lofreq/samutils.h
@@ -75,7 +75,7 @@ void
 normalize_alnerrprof(alnerrprof_t *alnerrprof);
 
 int
-parse_alnerrprof_statsfile(alnerrprof_t *alnerrprof, const char *path, bam_header_t *bam_header);
+parse_alnerrprof_statsfile(alnerrprof_t *alnerrprof, const char *path, bam_hdr_t *bam_header);
 
 void
 calc_read_alnerrprof(double *alnerrprof, unsigned long int *used_pos, 


### PR DESCRIPTION
For your consideration, this pull request converts _src/lofreq/*.c_ to use HTSlib functions directly rather than via the old samtools 0.1.x API. The old API has been unmaintained for many years and this conversion means that the lofreq code will need only HTSlib, not HTSlib and Samtools.

This compiles and runs but has not been heavily tested.

I've also updated the _configure_ script to use the same `./configure --with-htslib=DIR` configure option as used by Samtools. This enables it to build against either an HTSlib source directory or an installation directory in which HTSlib has already been installed. It would be possible to augment it so that the previous `./configure HTSLIB=/path` was a synonym of this, but at the moment it prints an error message suggesting `--with-htslib` be used instead.

Fixes #28 and fixes #52 et al.