### PR TITLE
Fix segfault due to ";HRUN=3" INFO field

### DIFF
--- a/src/lofreq/samutils.c
+++ b/src/lofreq/samutils.c
@@ -372,7 +372,7 @@ calc_read_alnerrprof(double *alnerrprof, unsigned long int *used_pos,
 
           }
      } /* for k */
-     /* calend not part of HTSlib API anymore? assert(pos == bam_calend(&b->core, bam_get_cigar(b))); FIXME correct assert? what if hard clipped? */
+     assert(pos == bam_endpos(b)); /* FIXME correct assert? what if hard clipped? */
      if (qpos != qlen) {
           LOG_FIXME("got qpos=%d and qlen=%d for cigar %s l_qseq %d\n", qpos, qlen, cigar_str_from_bam(b), b->core.l_qseq);
      }
@@ -593,7 +593,7 @@ count_cigar_ops(int *counts, int **quals, const bam1_t *b,
           }
      } /* for k */
 
-     /* bam_calend not part of new HTSlib API assert(qpos == bam_calend(&b->core, bam_get_cigar(b)));  FIXME correct assert? what if hard clipped? */
+     assert(qpos == bam_endpos(b)); /* FIXME correct assert? what if hard clipped? */
      if (qpos != qlen) {
           LOG_WARN("got qpos=%d and qlen=%d for cigar %s l_qseq %d in read %s\n", qpos, qlen, cigar_str_from_bam(b), b->core.l_qseq, bam_get_qname(b));
      }

--- a/src/lofreq/vcf.c
+++ b/src/lofreq/vcf.c
@@ -324,6 +324,7 @@ vcf_var_has_info_key(char **value, const var_t *var, const char *key) {
      char *token;
      char *info;
      char *info_ptr;
+     size_t key_len = strlen(key);
 
      if (value) {
           (*value) = NULL;
@@ -347,7 +348,9 @@ vcf_var_has_info_key(char **value, const var_t *var, const char *key) {
      while (token) {
           strsep(&info_ptr, field_delimiter);
           /*fprintf(stderr, "token=%s key=%s\n", token, key);*/
-          if (0 == strncasecmp(key, token, MIN(strlen(token), strlen(key)))) {
+          if (strlen(token) >= key_len &&
+              0 == strncasecmp(key, token, key_len) &&
+              (token[key_len] == '=' || token[key_len] == '\0')) {
                if (value) {
                     char *s = strchr(token, '=');
                     if (NULL != s) {


### PR DESCRIPTION
Fix `vcf_var_has_info_key()`'s key comparison, which causes the crash in #89 due to `;HRUN=3`:

```
NC_045512	1044	.	CA	C	94	PASS	;HRUN=3
```

Previously any key would be returned as being matched by the entirely empty "key=value" at the start of ";HRUN=3". Note that INFO is semicolon-**separated**, so this is in fact invalid VCF.

This resulted in a crash when e.g. lofreq_filter.c looking for "SB" expected a value but in this case the returned sb_char was NULL. Crash fixed by no longer returning a hit for "SB" in this case.

(Also convert a couple of previously missed legacy samtools API usages. Oops.)