### PR TITLE
Approximation shortcut

### DIFF
--- a/src/lofreq/Makefile.am
+++ b/src/lofreq/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -I../cdflib90/ -I../uthash $(HTSLIB_CPPFLAGS) @AM_CFLAGS@
-AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib
+AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@ 
 bin_PROGRAMS = lofreq
 lofreq_SOURCES = bam_md_ext.c bam_md_ext.h \
 bedidx.c bam_index.c \

--- a/src/lofreq/Makefile.am
+++ b/src/lofreq/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -I../cdflib90/ -I../uthash $(HTSLIB_CPPFLAGS) @AM_CFLAGS@
-AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@
+AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib
 bin_PROGRAMS = lofreq
 lofreq_SOURCES = bam_md_ext.c bam_md_ext.h \
 bedidx.c bam_index.c \
@@ -41,4 +41,4 @@ LIBS_for_htslib = -lhts
 endif
 
 # note: order matters
-lofreq_LDADD = $(LIBS_for_htslib) ../cdflib90/libcdf.a
+lofreq_LDADD = $(LIBS_for_htslib) ../cdflib90/libcdf.a -lgsl -lcblas -lm

--- a/src/lofreq/Makefile.am
+++ b/src/lofreq/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -I../cdflib90/ -I../uthash $(HTSLIB_CPPFLAGS) @AM_CFLAGS@
+AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -O3 -I../cdflib90/ -I../uthash $(HTSLIB_CPPFLAGS) @AM_CFLAGS@
 AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@
 bin_PROGRAMS = lofreq
 lofreq_SOURCES = bam_md_ext.c bam_md_ext.h \

--- a/src/lofreq/Makefile.am
+++ b/src/lofreq/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall -I../cdflib90/ -I../uthash $(HTSLIB_CPPFLAGS) @AM_CFLAGS@
-AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@ 
+AM_LDFLAGS = $(LDFLAGS_for_htslib) @AM_LDFLAGS@
 bin_PROGRAMS = lofreq
 lofreq_SOURCES = bam_md_ext.c bam_md_ext.h \
 bedidx.c bam_index.c \

--- a/src/lofreq/Makefile.am
+++ b/src/lofreq/Makefile.am
@@ -41,4 +41,4 @@ LIBS_for_htslib = -lhts
 endif
 
 # note: order matters
-lofreq_LDADD = $(LIBS_for_htslib) ../cdflib90/libcdf.a -lgsl -lcblas -lm
+lofreq_LDADD = $(LIBS_for_htslib) ../cdflib90/libcdf.a -l:libgsl.a -lcblas -lm

--- a/src/lofreq/snpcaller.c
+++ b/src/lofreq/snpcaller.c
@@ -1102,13 +1102,15 @@ snpcaller(long double *snp_pvalues,
         goto free_and_exit;
     }
 
-    double mu = 0;
-    for (int i = 0; i < num_err_probs; ++i) {
-        mu += err_probs[i];
-    }
-    const long double poibin_approximation = 1 - gsl_cdf_poisson_P(max_noncons_count - 1, mu);
-    if (poibin_approximation > sig_level + 0.01) {
-        goto free_and_exit;
+    if (num_err_probs > 1000) {
+        double mu = 0;
+        for (int i = 0; i < num_err_probs; ++i) {
+            mu += err_probs[i];
+        }
+        const long double poibin_approximation = 1 - gsl_cdf_poisson_P(max_noncons_count - 1, mu);
+        if (poibin_approximation > sig_level + 0.01) {
+            goto free_and_exit;
+        }
     }
     probvec = poissbin(&pvalue, err_probs, num_err_probs,
                        max_noncons_count, bonf_factor, sig_level);

--- a/src/lofreq/snpcaller.c
+++ b/src/lofreq/snpcaller.c
@@ -1102,13 +1102,14 @@ snpcaller(long double *snp_pvalues,
         goto free_and_exit;
     }
 
-    if (num_err_probs > 1000) {
-        double mu = 0;
+    // Only approximate if sufficient data available
+    if (num_err_probs > 100) {
+        long double mu = 0;
         for (int i = 0; i < num_err_probs; ++i) {
             mu += err_probs[i];
         }
         const long double poibin_approximation = 1 - gsl_cdf_poisson_P(max_noncons_count - 1, mu);
-        if (poibin_approximation > sig_level + 0.01) {
+        if (poibin_approximation > sig_level + 0.05) {
             goto free_and_exit;
         }
     }
@@ -1131,7 +1132,6 @@ snpcaller(long double *snp_pvalues,
 #endif
         goto free_and_exit;
     }
-
 
     /* report p-value for each non-consensus base
      */

--- a/src/lofreq/snpcaller.c
+++ b/src/lofreq/snpcaller.c
@@ -1046,6 +1046,7 @@ poissbin(long double *pvalue, const double *err_probs,
               *pvalue = LDBL_MAX; /* otherwise set to 1 which might pass filters */
          }
     }
+
     return probvec;
 }
 
@@ -1139,6 +1140,7 @@ snpcaller(long double *snp_pvalues,
              feclearexcept(FE_ALL_EXCEPT);
 
              pvalue = expl(probvec_tailsum(probvec, noncons_counts[i], max_noncons_count+1));
+
              errsv = errno;
              if (errsv || fetestexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW)) {
                   /* failed expl will set pvalue either to 0 or 1,


### PR DESCRIPTION
Hello! 

This is a PR for an additional heuristic in the LoFreq algorithm. Many times, the Poisson Binomial calculation either yields numbers that are extremely high p-values extremely low p-values. Therefore, we can use an approximation to cut out performing an exact calculation when the p-value is sufficiently above the significance level. By specifying some threshold above the significance level, we can be extremely confident that the approximation  shortcut will never skip exact calculation on columns which have significant p-values. 

We use a [Poisson approximation to the binomial distribution](https://www.jstor.org/stable/2237582) where the mean is the sum of the probabilities and the variable remains the same (most frequent variant count). There are indeed other approximations that we plan on trying, such as the [refined normal approximation](https://www.emis.de/journals/HOA/IJMMS/Volume2005_5/728.pdf) (see section 3 of [this](https://www.sciencedirect.com/science/article/pii/S0167947312003568) pub for a brief explanation of the approximations). To calculate the Poisson CDF, we use the [GNU scientific library](https://www.gnu.org/software/gsl/doc/html/intro.html). I have not added a `--with-gsl` flag to the configure (I do not understand `.m4` wizardry yet :slightly_smiling_face:), so depending on where it is installed for users, they may need to add the location of the `libopenblas.so.0` shared library to their `LD_LIBRARY_PATH` environment variable in order to run. 