### PR TITLE
Bcftools pparallel

### DIFF
--- a/src/lofreq/plp.c
+++ b/src/lofreq/plp.c
@@ -816,7 +816,11 @@ void compile_plp_col(plp_col_t *plp_col,
       * n_plp[i] - m
       */
      ref_base = (ref && pos < ref_len)? ref[pos] : 'N';
-
+     /* Added by Ryan Morin in an attempt to mitigate issues with non-ACTG characters in the reference
+     An example position (hg38) affected by this is chr17   83129591  (the reference base is W) */
+     if (! (ref_base == 'A' || ref_base == 'C' || ref_base == 'T' || ref_base == 'G' || ref_base == 'N')){
+          ref_base = 'N';
+     }
      plp_col_init(plp_col);
      plp_col->target = strdup(target_name);
      plp_col->pos = pos;

--- a/src/scripts/lofreq2_call_pparallel.py
+++ b/src/scripts/lofreq2_call_pparallel.py
@@ -166,16 +166,23 @@ def concat_vcf_files(vcf_files, vcf_out, source=None):
     """
 
     assert not os.path.exists(vcf_out)
-
-    cmd = ['lofreq', 'vcfset', '-a', 'concat', '-o', vcf_out, '-1']
+    #I didn't address the FIXME issue noted above but another bug was fixed here.
+    #This now uses bcftools to overcome systematic failures of merging with certain data sets due to multi-allelic variants
+    cmd = ['bcftools', 'concat', '-a', '-O', 'z', '-o', vcf_out]
     cmd.extend(vcf_files)
+    idx = ['bcftools','index','-t', vcf_out]
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         LOG.fatal("The following command failed with return code %d: %s" % (
             e.returncode, ' '.join(cmd)))
         sys.exit(1)
-
+    try:
+        subprocess.check_call(idx)
+    except subprocess.CalledProcessError as e:
+        LOG.fatal("The following command failed with return code %d: %s" % (
+            e.returncode, ' '.join(cmd)))
+        sys.exit(1)
 
 def sq_list_from_bam_samtools(bam):
     """Extract SQs listed in BAM head using samtools


### PR DESCRIPTION
This pull request addresses a major issue that has been affecting us when we run Lofreq on whole genome data in somatic mode. Non-ACTGN characters in the reference (e.g. IUPAC ambiguity codes such as W, R, Y) cause strange behaviour and lead to malformed/garbled lines in the VCF somewhat consistently (see #106). The change to plp.c forces these positions to be ignored as it does for Ns in the reference. We have also changed merging to rely on bcftools in an earlier attempt to address this issue (see #108). That change may not be necessary at this point with the current patch to plp.c

I'm interested in having at least the plp.c change added to future releases of lofreq so conda users can benefit from this improvement. 