### PR TITLE
Fix: error caused by including the gsl header files.

### DIFF
--- a/src/lofreq/snpcaller.c
+++ b/src/lofreq/snpcaller.c
@@ -43,8 +43,11 @@
 #include "fet.h"
 #include "utils.h"
 #include "log.h"
+
+#ifdef HAVE_LIBGSL
 #include "gsl/gsl_randist.h"
 #include "gsl/gsl_cdf.h"
+#endif
 
 #include "snpcaller.h"
 #if TIMING


### PR DESCRIPTION
This pull request fixes a build error: "fatal error: gsl/gsl_randist.h: No such file or directory"   (#110).
The error occurs when the libgsl library is not installed on the system.

A check is added to solve this problem. The check ensures that the gsl header files are included **only** when the libgsl library is installed and detected on the system. The detection is done by the [AC_CHECK_LIB in configure.ac](https://github.com/CSB5/lofreq/blob/master/configure.ac#L154).

The patched version has been tested to build and run successfully: regardless of whether the library is missing and whether the --approx-threshold option is used, the program builds and runs successfully.
